### PR TITLE
Fix fullscreen for OS X 10.7

### DIFF
--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -6030,10 +6030,15 @@ typedef struct
 
 
   /* enable fullscreen button */
-  [win setCollectionBehavior:__NSWindowCollectionBehaviorManaged
-       | __NSWindowCollectionBehaviorFullScreenPrimary
-       | __NSWindowCollectionBehaviorParticipatesInCycle
-       | __NSWindowCollectionBehaviorFullScreenAuxiliary];
+  if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5) {
+    [win setCollectionBehavior:__NSWindowCollectionBehaviorManaged
+         | __NSWindowCollectionBehaviorFullScreenPrimary
+         | __NSWindowCollectionBehaviorFullScreenAuxiliary];
+  } else {
+    [win setCollectionBehavior:__NSWindowCollectionBehaviorManaged
+	 | __NSWindowCollectionBehaviorParticipatesInCycle];
+  }
+
 
   FRAME_TOOLBAR_HEIGHT (f) = 0;
 
@@ -6695,10 +6700,15 @@ enum {
       [f setContentSize:[[self screen] frame].size];
       [f setTitle:[self title]];
       [f makeKeyAndOrderFront:nil];
-      [f setCollectionBehavior:__NSWindowCollectionBehaviorManaged
-	    | __NSWindowCollectionBehaviorFullScreenPrimary
-	    | __NSWindowCollectionBehaviorParticipatesInCycle
-	    | __NSWindowCollectionBehaviorFullScreenAuxiliary];
+
+      if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5) {
+        [f setCollectionBehavior:__NSWindowCollectionBehaviorManaged
+	   | __NSWindowCollectionBehaviorFullScreenPrimary
+	   | __NSWindowCollectionBehaviorFullScreenAuxiliary];
+      } else {
+        [f setCollectionBehavior:__NSWindowCollectionBehaviorManaged
+	   | __NSWindowCollectionBehaviorParticipatesInCycle];
+      }
 
 
       return f;


### PR DESCRIPTION
Most apps allocate their own virtual screen when switching to full screen in Lion. Aquamacs takes over the desktop instead. This commit fixes this by setting the spaces-related window flag only on pre-Lion OSes, and only setting the Lion-related fullscreen flags when running on Lion.

This is my first attempt at hacking on an OS X app or in Objective-C, so feedback is welcomed.
