### PR TITLE
Add -f to rm DOC-* so the command succeeds if there are no such files.

### DIFF
--- a/aquamacs/build/build24.sh
+++ b/aquamacs/build/build24.sh
@@ -51,7 +51,7 @@ test $OMIT_AUTOGEN || ./autogen.sh ; \
 make clean ; \
 make all ; \
 make install ; \
-rm etc/DOC-* ; \
+rm -f etc/DOC-* ; \
 
 
 # generate symbol archive


### PR DESCRIPTION
This line was failing building aquamacs24 since there are no such named files.
