### PR TITLE
Fix call to aquamacs-call-viewer

### DIFF
--- a/aquamacs/src/site-lisp/edit-modes/auctex-config.el
+++ b/aquamacs/src/site-lisp/edit-modes/auctex-config.el
@@ -243,7 +243,7 @@ no reference is found, execute the LaTeX View command."
     (("Preview" "open -a Preview.app %o")
      ;;       ("Skim"  "/Applications/Skim.app/Contents/SharedSupport/displayline -b %n %o %b")
      ;;       ("Skim"   "%(Ad)/Contents/MacOS/bin/displayline -b %n %o %b")
-     ("Skim" ("(aquamacs-call-viewer %n \"%b\")"))))
+     ("Skim" "(lambda () (aquamacs-call-viewer %n \"%b\"))")))
    (TeX-view-predicate-list 
     ((output-pdf-skim-running 
       (and (string-match "pdf" (TeX-output-extension))


### PR DESCRIPTION
The call to `aquamacs-call-viewer` was not recognised as a function by `TeX-run-discard-or-function`. Therefore, it was executed as a process command and silently failed.
