### PR TITLE
Improve terminal script performance and error handling

### DIFF
--- a/aquamacs/src/commandline-tool/aquamacs
+++ b/aquamacs/src/commandline-tool/aquamacs
@@ -3,12 +3,15 @@
 # Aquamacs Emacs starter
 # (C) 2007, 2008, 2009 Aquamacs Project
 
+use strict;
+
 # Revisions
 # 1.0 - first version to be included with Aquamacs [2007-03-17 David Reitter] 
 # 1.1 - delayed deletion of new files [2008-11-12 David Reitter]
 # 1.2 - remove hard-coding of application path; consequently, remove sudo functionality
 #     - shorter delay before deleting file
 # 1.3 - changed application name (Aquamacs 2.0)
+# 1.4 - do the right thing if files have weird names like a"b or some can't be created [2016-05-05 Steve Sanbeg]
 
 # to-do: re-implement in C (or as a shell script)
 
@@ -16,15 +19,20 @@
 # $app_path = '<AQUAMACS-PATH>';
 # $pid = qx"ps auxc | awk '/^$ENV{'USER'} .* Aquamacs\$/ {print \$2}'";
 
-my $args = "";
-my $tmpfiles = "";
+my @args;
+my @tmpfiles;
 
 for my $f (@ARGV) {
-  $args .= '"'.$f.'" ';
-  $tmpfiles .= '"'.$f.'" ' if (! -e $f);
+  if (-e $f) {
+    push @args, $f;
+  } elsif (open my($tfh), '>', $f) {
+    close $tfh;
+    push @args, $f;
+    push @tmpfiles, $f;
+  } else {
+    warn "$f: $!\n";
+  }
 }
-
-system("touch $args") if ($tmpfiles);
  
  # there is still an issue:
  # if the sudo emacs is still open, it will 
@@ -36,15 +44,18 @@ system("touch $args") if ($tmpfiles);
     # we can only call "open" with existing files.
     # that's why we create them just for the "open" call.
 
-    system("open -a Aquamacs.app $args");
+    system('open', '-a', 'Aquamacs.app', @args);
      
 #  } else {
 #    system("$app_path/Contents/MacOS/Aquamacs $args 2>/dev/null &");
 #  }
 
 # delay deletion because AE drag&drop doesn't work with non-existing documents
-system("(sleep 3; rm $tmpfiles) &") if ($tmpfiles);
- 
-exit;
+
+if (@tmpfiles and fork == 0) {
+  sleep 3;
+  unlink $_ for @tmpfiles;
+  exit;
+}
 
 


### PR DESCRIPTION
Avoid unnecesarily calling out to shell commands.
Avoid round tripping between arrays & strings, so files with quotes in the name (a"b) don't generate weird errors
Warn & skip files that can't be created
