### PR TITLE
Replaced/Removed deprecated methods

### DIFF
--- a/src/nsfns.m
+++ b/src/nsfns.m
@@ -1804,7 +1804,8 @@ capitalized in the same way. */)
   sc = [NSSpellChecker sharedSpellChecker];
 
   Lisp_Object retval = Qnil;
-  NSArray *guesses = [sc guessesForWord: [NSString stringWithUTF8String: SDATA (word)]];
+  NSString *the_word = [NSString stringWithUTF8String: SDATA (word)];
+  NSArray *guesses = [sc guessesForWordRange:NSMakeRange(0, [the_word length]) inString:the_word language:[sc language] inSpellDocumentWithTag:0];
   int arrayCount = [guesses count];
   int i = arrayCount;
   while (--i >= 0)

--- a/src/nsimage.m
+++ b/src/nsimage.m
@@ -190,15 +190,8 @@ ns_resize_truedpi_image (void *eImg, int respect_dpi, Lisp_Object scale_factor, 
   
   // we'll optimize for the main screen.
   // needed to pick the right representation e.g., when HiDPI image is provided.
-  if ([image respondsToSelector: @selector (bestRepresentationForRect:context:hints:)])
-    {
-      // Choose the smallest (full-resolution) image representation
-      imgRep = [image bestRepresentationForRect: NSMakeRect(100,100,2,2)  context:nil hints: nil];
-    }
-  else
-    {
-      imgRep = [image bestRepresentationForDevice: nil];
-    }
+  // Choose the smallest (full-resolution) image representation
+  imgRep = [image bestRepresentationForRect: NSMakeRect(100,100,2,2)  context:nil hints: nil];
   
   if (imgRep == nil)
       return;


### PR DESCRIPTION
* Replaced deprecated guessesForWord with guessesForWordRange

* Since we’re on 10.6+, the method bestRepresentationForRect is always
available so the code that checks this is unnecessary. This also gets
rid of the deprecated (and unused) call to bestRepresentationForDevice.