### PR TITLE
Again allowing flexible spaces in toolbar

### DIFF
--- a/src/nsmenu.m
+++ b/src/nsmenu.m
@@ -1226,9 +1226,7 @@ update_frame_tool_bar (struct frame *f)
       if (// EQ (TOOLPROP (TOOL_BAR_ITEM_TYPE), Qt) ||
 	  (STRINGP (label) && strcmp("--", SSDATA (label)) == 0))
         {
-          /* Skip separators.  Newer macOS don't show them, and on
-             GNUstep they are wide as a button, thus overflowing the
-             toolbar most of the time.  */
+          [toolbar addDisplayItemSpacerWithIdx: k++ tag:i key: keyText];
           continue;
         }
 


### PR DESCRIPTION
Flexible spaces where removed from the toolbar (and customisation),
this puts them back.

The comment for the removal stated that flexible spaces aren’t shown on
newer macOS versions, but at least on El Capitan (10.11) they still do!