### PR TITLE
Add missing quote to ns symbol in comparison to window-system.

### DIFF
--- a/lisp/menu-bar.el
+++ b/lisp/menu-bar.el
@@ -1119,7 +1119,7 @@ mail status in mode line"
                                (:visible (not (eq window-system 'ns)))))
 
     (bindings--define-key menu [datetime-separator] `(menu-item "" nil
-                          :visible (not (eq window-system ns))))
+                          :visible (not (eq window-system 'ns))))
 
     (bindings--define-key menu [column-number-mode]
       (menu-bar-make-mm-toggle column-number-mode


### PR DESCRIPTION
Buried in lisp/menu-bar.el, there was a comparison of the value of window-system to the unquoted symbol ns. This pull request adds the quote.
