### PR TITLE
Small fixes in fringe menu and description of aquamacs-left-char

### DIFF
--- a/aquamacs/src/site-lisp/aquamacs.el
+++ b/aquamacs/src/site-lisp/aquamacs.el
@@ -326,7 +326,7 @@ un-Mac-like way when you select text and copy&paste it.")))
    (setq fringe-mode
          (cons (cdr-safe (assq 'left-fringe default-frame-alist))
                (cdr-safe (assq 'right-fringe default-frame-alist))))
-   (if (eq fringe-mode '(nil)) (setq fringe-mode nil))
+   (if (equal fringe-mode '(nil)) (setq fringe-mode nil))
 
    ;; run this after the frames have been established
    ;; via default-frame-alist

--- a/aquamacs/src/site-lisp/macosx/aquamacs-frame-setup.el
+++ b/aquamacs/src/site-lisp/macosx/aquamacs-frame-setup.el
@@ -68,7 +68,7 @@ even when minimal fringes are used. (Aquamacs)"
 (setq default-indicate-empty-lines t)
 
 (aquamacs-define-the-fringe-bitmap)
-(setq fringe-mode '(1 . 1)) ;; to reflect the default.
+(setq fringe-mode nil) ;; to reflect the default.
 ;; This is a hack because fringe-mode likes to round up stuff.
 
 ;; set default colors

--- a/aquamacs/src/site-lisp/macosx/aquamacs-menu.el
+++ b/aquamacs/src/site-lisp/macosx/aquamacs-menu.el
@@ -872,7 +872,7 @@ contains `turn-on-auto-fill', `turn-on-word-wrap' or `auto-detect-wrap'."
   '(menu-item "Left and Right" menu-bar-showhide-fringe-menu-customize-reset
 	      :help "Default width fringe on both left and right side"
 	      :visible (display-graphic-p)
-	      :button (:radio . (or (eq fringe-mode nil) (equal fringe-mode '(nil))))))
+	      :button (:radio . (eq fringe-mode nil))))
 
   
 (define-key-after menu-bar-options-menu [file-backups]

--- a/aquamacs/src/site-lisp/macosx/aquamacs-menu.el
+++ b/aquamacs/src/site-lisp/macosx/aquamacs-menu.el
@@ -831,10 +831,10 @@ contains `turn-on-auto-fill', `turn-on-word-wrap' or `auto-detect-wrap'."
   (fringe-mode (cons 4 0)))
 
 (defun aquamacs-menu-bar-showhide-fringe-menu-customize-tiny ()
-  "Display small fringes only on the left of each window."
+  "Display tiny fringes on the left and right of each window."
   (interactive)
   (require 'fringe) 
-  (fringe-mode (cons 1 1)))
+  (fringe-mode '(1)))
 
   ;; Unfortunately, fringe-mode likes to round up fringes.
   ;; Therefore, we set both to 1.
@@ -866,13 +866,13 @@ contains `turn-on-auto-fill', `turn-on-word-wrap' or `auto-detect-wrap'."
 	      aquamacs-menu-bar-showhide-fringe-menu-customize-tiny
 	      :help "Tiny fringes, left and right"
 	      :visible ,(display-graphic-p)
-	      :button (:radio . (equal fringe-mode '(1 . 1)))) 'none)
+	      :button (:radio . (equal fringe-mode '(1)))) 'none)
 
 (define-key menu-bar-showhide-fringe-menu [default]
   '(menu-item "Left and Right" menu-bar-showhide-fringe-menu-customize-reset
 	      :help "Default width fringe on both left and right side"
 	      :visible (display-graphic-p)
-	      :button (:radio . (eq fringe-mode nil))))
+	      :button (:radio . (or (eq fringe-mode nil) (equal fringe-mode '(nil))))))
 
   
 (define-key-after menu-bar-options-menu [file-backups]

--- a/aquamacs/src/site-lisp/macosx/osxkeys.el
+++ b/aquamacs/src/site-lisp/macosx/osxkeys.el
@@ -144,7 +144,7 @@ after updating this variable.")
 
 (defun aquamacs-left-char ()
   "Move point to the left or the beginning of the region.
- Like `backward-char', but moves point to the beginning of the region
+ Like `left-char', but moves point to the beginning of the region
 provided `cua-mode' and the mark are active."
   (interactive)
   (let ((this-command 'left-char)) ;; maintain compatibility


### PR DESCRIPTION
* Fixes the missing tick-mark in front of the left & right (default) option of the fringe mode in the menu
* Fixes the description of the tiny fringe-mode and changes it to `'(1)` instead of `'(1 . 1)`
* Fixes the default value showing as truly the default: `nil` instead of `(nil)`
* Fixes the description of aquamacs-left-char