### PR TITLE
Update backquote style to modern.

### DIFF
--- a/aquamacs/src/site-lisp/edit-modes/applescript-mode.el
+++ b/aquamacs/src/site-lisp/edit-modes/applescript-mode.el
@@ -244,9 +244,9 @@ for a block opening statement are given this extra offset."
 ;; Utilities
 (defmacro as-safe (&rest body)
   "Safely execute BODY, return nil if an error occurred."
-  (` (condition-case nil
-         (progn (,@ body))
-       (error nil))))
+  `(condition-case nil
+       (progn ,@body)
+     (error nil)))
 
 (defsubst as-keep-region-active ()
   "Keep the region active in XEmacs."


### PR DESCRIPTION
The prevents the message "Loading ‘applescript-mode’: old-style
backquotes detected!" from being displayed.

This is a very minor point, but every time one loads applescript-mode.el bundled with Aquamacs, that warning message is displayed. This commit simply updates the way the code using backquote is written to the modern emacs lisp style.