### PR TITLE
Remove setting of ess-etc-directory in mode-preloads.el

### DIFF
--- a/aquamacs/src/site-lisp/mode-preloads.el
+++ b/aquamacs/src/site-lisp/mode-preloads.el
@@ -175,11 +175,6 @@ or `CVS', and any subdirectory that contains a file named `.nosearch'."
 
 
 
-
-(setq ess-etc-directory (concat  (mac-resources-path)
-				  "lisp/aquamacs/edit-modes/ess-mode/etc"
-				  ))
-
 (aquamacs-set-defaults 
  '((html-helper-mode-uses-JDE nil)))
 (autoload 'html-helper-mode "html-helper-mode" 


### PR DESCRIPTION
Remove setting of ess-etc-directory from mode-preloads.el, to be compatible with less >= 18.10.  Based on thread on OS X Emacs mailing list, 9-Jan-2019.