### PR TITLE
Fix homebrew build for gnutls

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -471,21 +471,6 @@ $(srcdir)/src/stamp-h.in: $(AUTOCONF_INPUTS)
 install: all install-arch-indep install-etcdoc install-arch-dep install-$(NTDIR) blessmail install-aquamacs
 	@true
 
-# The prepinstall runs a script that copies shared libraries from
-# /usr/local into the application bundle. This is mainly needed for
-# gnutls. If necessary, the libraries are recompiled for the same Mac
-# OS deployment target before they are copied. Arguments are:
-# - the Mac OS deployment version to use
-# - the path to the just-build application bundle
-# The script may modify the existing homebrew installation with the
-# recompilation.
-
-install-brewed-libraries:
-	@echo If Homebrew is installed, build and copied brewed
-	@echo shared libraries for distribution
-	sh aquamacs/build/build-homebrew-libraries.sh "$(MACOSX_DEPLOYMENT_TARGET)" \
-           nextstep/Aquamacs.app
-
 ## Ensure that $subdir contains a subdirs.el file.
 ## Here and elsewhere, we set the umask so that any created files are
 ## world-readable.

--- a/aquamacs/build/build-homebrew-libraries.sh
+++ b/aquamacs/build/build-homebrew-libraries.sh
@@ -10,37 +10,66 @@
 #
 # The primary use of this script is for the Aquamacs build machine,
 # because it is really only relevant in building the Aquamacs binary
-# distribution. It modifies Homebrew recipes. The modified versions
-# are normally merged with a Homebrew update, so in most cases it will
-# not be necessary to rebuild the recipes each time Aquamacs is built.
-# Any changes can be cleaned up using git in the Homebrew recipe
-# directory if needed.
+# distribution. It modifies Homebrew recipes. In almost all cases, the
+# original recipes are restored after the script runs. This means that
+# the relevant libraries will be rebuilt each time this script is run.
+
+# For debugging, the environment variables can be used:
+#   BUILD_HOMEBREW_DEBUG="-d"
+# If this variable is defined, the -d option is passed to
+# 'brew reinstall' to provide homebrew debugging information.
+# In addition, if the variable is defined at all, this script
+# does not remove the modified homebrew recipe files.
 
 # Usage:
-# sh build-libraries.sh NEW-CFLAGS BUNDLE-DIR
+# sh build-libraries.sh BUNDLE-DIR MIN-VERSION
 
-MIN_VERSION=${1:-"10.9"}
-BUNDLE_DIR="$2"
+BUNDLE_DIR="$1"
+MIN_VERSION=${2:-"10.11"}
+
+if [ "${1}x" = x -o "${1}" = "-h"  -o "${1}" = "--help"  ]; then
+   echo "Usage: sh build-libraries.sh BUNDLE-DIR [MIN-VERSION]"
+   echo "    BUNDLE-DIR is the directory containing a compiled "
+   echo "        Aquamacs, typically named Aquamacs.app"
+   echo "    MIN-VERSION is the desired minimum Mac OS version."
+   echo "        Defaults to ${MIN_VERSION}"
+   exit 1
+fi
 
 APP="${BUNDLE_DIR}/Contents/MacOS/Aquamacs"
 DEST_LIB_DIR="${BUNDLE_DIR}/Contents/MacOS/lib"
 NEW_CFLAGS="-mmacosx-version-min=${MIN_VERSION}"
 
+if [ ! -d ${BUNDLE_DIR} ]; then
+    echo "Error: ${BUNDLE_DIR} does not exist or is not a directory"
+    exit 1
+fi
+
+if [ ! -f ${APP} ]; then
+    echo "Error: ${APP} does not exist in ${BUNDLE_DIR}"
+    exit 1
+fi
+
 # Add configuration for additional CFLAGS to a Homebrew formula
-# Usage: add_cflags <pkg> <new-cflags>
+# Usage: add_cflags <formula-file>
 add_cflags () {
-    formula_dir="$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/"
-    formula="${formula_dir}/${1}.rb"
+    formula=$1
 
     # Don't add anything if the file already sets CFLAGS
-    grep 'ENV["CFLAGS"]' "${formula}" >/dev/null && return
+    grep 'ENV["CFLAGS"]' "${formula}" >/dev/null
+    if [ $? -eq 0 ]; then
+        echo "Formula ${formula} already sets CFLAGS; cannot rebuild"
+        exit 1
+    fi
 
     # Be careful with the formatting of this value to get all the quotes
     # right. We don't use single quotes in the array index, which would be
     # normal in Ruby, because they get messed up between the shell and the
     # sed command later.
 
-    NEW_FLAG_CMD="ENV[\"CFLAGS\"]=\"${NEW_CFLAGS}\" # aquamacs-libraries"
+    # Set both CFLAGS and LDFLAGS.
+    NEW_CFLAGS_CMD="ENV[\"CFLAGS\"]=\"${NEW_CFLAGS}\" # aquamacs-libraries"
+    NEW_LDFLAGS_CMD="ENV[\"LDFLAGS\"]=\"${NEW_CFLAGS}\" # aquamacs-libraries"
 
     # First, delete any existing ENV line so we don't have conflicts.
     /usr/bin/sed -i '' '/aquamacs-libraries/d' ${formula} || exit 1
@@ -52,7 +81,8 @@ add_cflags () {
     # Homebrew recipe.
 
     /usr/bin/sed -i '' -e "/def install/a\\
-    \    ${NEW_FLAG_CMD}\\
+    \    ${NEW_CFLAGS_CMD}\\
+    \    ${NEW_LDFLAGS_CMD}\\
     " "${formula}" || exit 1
 }
 
@@ -61,14 +91,33 @@ add_cflags () {
 # Note: we have a special rule for gnutls to add a configuration argument.
 brew_reinstall () {
     pkg=$1
-    if [ "${pkg}" = "gnutls" ]; then
-        BREW_ARGS="--without-p11-kit"
-    else
-        BREW_ARGS=""
+    # if [ "${pkg}" = "gnutls" ]; then
+    #     BREW_ARGS="--without-p11-kit"
+    # else
+    #     BREW_ARGS=""
+    # fi
+
+    formula_dir="$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/"
+    formula="${formula_dir}/${pkg}.rb"
+
+    if [ ! -f ${formula} ]; then
+        echo "*** ${pkg}: Formula not available: ${formula}"
+        exit 1
     fi
-    add_cflags ${pkg} ${NEW_CFLAGS}
-    # XXXX REMOVE -d!
-    brew reinstall -d --build-from-source ${BREW_ARGS} ${pkg} || exit 1
+    echo "Rebuilding ${pkg} with ${NEW_CFLAGS}"
+
+    # Make a backup copy of the file we are about to modify
+    BACKUP="${formula}.bak"
+    cp ${formula} ${BACKUP}
+
+    add_cflags ${formula} ${NEW_CFLAGS}
+    brew reinstall -d --build-from-source -v ${BREW_ARGS} ${pkg}
+    rebuild_status=$?
+    mv ${BACKUP} ${formula}
+    if [ "$rebuild_status" -ne 0 ]; then
+        echo "Rebuild of ${pkg} failed...exiting"
+        exit 1
+    fi
 }
 
 # Get the relevant shared libraries used by the executable or library
@@ -97,18 +146,20 @@ ensure_min_version () {
 process_dependencies () {
     local target="${1}"
     local outdir="${2}"
+    local lib = ""
     echo "* Process ${target}"
     for lib in $(get_local_libs ${target}); do
+        echo "** Work on ${lib}"
         local pkg=$(echo $lib | awk -F/ '{print $5}')
         local libname="$(basename $lib)"
         local destlib="${outdir}/${libname}"
+        process_dependencies "${lib}" "${outdir}"
         ensure_min_version "$lib" "$pkg"
         # Copy the shared library to the app bundle and fix up paths
         cp "${lib}" "${outdir}" || exit 1
         chmod u+w ${destlib}
         install_name_tool -change "${lib}" "@executable_path/lib/${libname}" \
              "${target}"
-        process_dependencies "${destlib}" "${outdir}"
     done
 }
 

--- a/aquamacs/build/build.sh
+++ b/aquamacs/build/build.sh
@@ -48,8 +48,8 @@ echo "Compiler flags: $FLAGS"
 # do not use MacPorts / fink libraries
 # do not use binaries either (e.g., gnutls would be recognized)
 
-# We will run only on 10.9 and later.
-MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-"10.9"}
+# We will run only on 10.11 and later.
+MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-"10.11"}
 export MACOSX_DEPLOYMENT_TARGET
 
 FINALMESSAGE=""
@@ -59,7 +59,7 @@ then
 # we're going to choose the oldest SDK we have (starting with 10.9)
 # this should guarantee backwards compatibility up to that SDK version.
 # for current Aquamacs, this will typically be 10.9
-for VERS in 10.9 10.10 10.11 10.12 10.13 10.14; do
+for VERS in 10.11 10.12 10.13 10.14; do
     SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${VERS}.sdk"
     if [ -d "$SDK" ]; then
         FINALMESSAGE="This build will be compatible with OS X $VERS onwards."

--- a/aquamacs/doc/latex/changelog.tex
+++ b/aquamacs/doc/latex/changelog.tex
@@ -9,6 +9,8 @@
 \vskip2em
 \begin{itemize}
 \item Fixed a compatibility issue with macOS Mojave.
+\item In order to provide compatibility with gnutls, the oldest  supported version of Mac OS X is now El Capitan (10.11).
+\item Aquamacs is now compiled and distributed with a copy of the gnutls library to enable secure web connections. The version in this distribution is 3.6.5. Only the shared library  and its library dependencies are included. This was done because Emacs has removed support for using the openssl command line tool shipped with Mac OS X. Code for building the libraries contributed by Win Treese.
 \end{itemize}
 
 


### PR DESCRIPTION
Attempt at finishing script to add gnutls libraries to bundle.

1. Updated the build-homebrew-libraries.sh script
2. Removed references to it from Makefile.in
3. Updated the minimum Mac OS X version to 10.11.
4. Added some notes to the changelog (and please review for appropriateness)

I think it should work reasonably well for release builds. It requires an update to homebrew to fix a homebrew bug that was getting in the way, but that fix is in the distributed version now.

Some other notes:
1. You can hook in the build-homebrew-libraries.sh script anywhere you want at the end of the build process. The usage is

   sh aquamacs/build/build-homebrew-libraries.sh <path to application bundle> [<min-version>]

   From the top-level aquamacs directory used for running build-aquamacs, the path would normally be nextstep/Aquamacs.app. The minimum version defaults to 10.11.

2. Anyone building Aquamacs on their own should probably have gnutls available now, whether through homebrew or not. They don't need to run the script, since it will just work with the local version and they presumably won't be distributing it.
