### PR TITLE
Update homebrew script to work with nightly build process

### DIFF
--- a/aquamacs/build/build.sh
+++ b/aquamacs/build/build.sh
@@ -13,8 +13,8 @@ OLD_SDK=0
 
 case "$1" in
 '-release')
-  # do not use MacPorts / fink libraries for binary compatibility
-  PATH=$AUTOTOOLS:/bin:/sbin:/usr/bin:/usr/sbin
+  # Include /usr/local/bin/for finding homebrew libaries
+  PATH=$AUTOTOOLS:/usr/local/bin:/bin:/sbin:/usr/bin:/usr/sbin
   export GZIP_PROG=`which gzip`
   echo "Building Aquamacs (release)."
   OMIT_AUTOGEN=
@@ -23,8 +23,8 @@ case "$1" in
   OLD_SDK=1
   ;;
 '-flags')
-  # do not use MacPorts / fink libraries for binary compatibility
-  PATH=$AUTOTOOLS:/bin:/sbin:/usr/bin:/usr/sbin
+  # Include /usr/local/bin/for finding homebrew libaries
+  PATH=$AUTOTOOLS:/usr/local/bin:/sbin:/usr/bin:/usr/sbin
   export GZIP_PROG=`which gzip`
   echo "Building Aquamacs (nightly build)."
   OMIT_AUTOGEN=

--- a/aquamacs/build/nightly-build.sh
+++ b/aquamacs/build/nightly-build.sh
@@ -57,8 +57,8 @@ mkdir builds 2>/dev/null
 # one step builds on the next:
 aquamacs/build/build.sh -release >>$LOG 2>>$LOG  && \
 date >>$LOG && \
-echo "Building and installing Homebrew libraries." >>$LOG && \
-aquamacs/build/build-homebrew-libraries.sh $APP >>$LOG 2>>$LOG && \
+echo "Copying Homebrew libraries to app bundle." >>$LOG && \
+aquamacs/build/build-homebrew-libraries.sh -bundle $APP >>$LOG 2>>$LOG && \
 echo "Packaging Aquamacs." >>$LOG && \
 cd `dirname ${APP}` && \
 tar cjf ${BLD} Aquamacs.app && \


### PR DESCRIPTION
This commit has the following changes:

1. The build.sh script has been modified to include /usr/local/bin in
PATH for both the nightly and release builds, which seems to be the
change needed for configure to find the additional libraries, such as
gnutls. I have may missed something about that change, so it should be
double-checked.

2. The nightly-build.sh has been updated to use the -bundle option for
build-homebrew-libraries.sh as described below. There is likely a
corresponding change to be made for final release builds.

3. A revamped build-homebrew-libraries.sh.

- With the -rebuild option, it recompiles and reinstalls any homebrew
  libraries used in the Aquamacs binary as needed to match the target
  MacOS version number. It recursively rebuilds any libraries
  referenced in those that Aquamacs depends directly on. Nothing in
  the application bundle is modified in this process. It is assumed
  that -rebuild is used when homebrew is updated in general.

- With the -bundle option, it recursively copies the dependent
  libraries into the MacOS/lib directory of the Aquamacs bundle, and
  rewrites the Aquamacs binary to point to those versions of the
  shared library. In this case, it verifies that the library versions
  are compatible and exits with an error if they are not. It also
  performs some basic sanity checks on the resulting copies.

The script tries to be pretty careful about what it is doing, but
there may be differences from the build machine and my system that
require some other small changes. But I think this is pretty close to
usable.