### PR TITLE
Remove limit to checking for gnutls.

### DIFF
--- a/aquamacs/build/build-homebrew-libraries.sh
+++ b/aquamacs/build/build-homebrew-libraries.sh
@@ -244,16 +244,6 @@ if [ ! -d /usr/local/Homebrew ]; then
     exit 0
 fi
 
-# Special check for Aquamacs: only allow gnutls
-LOCAL_LIBS="$(otool -L ${APP} | grep /usr/local | grep -v libgnutls)"
-if [ "${LOCAL_LIBS}"x != x ]; then
-    echo "Unexpected local libraries detected:"
-    echo ${LOCAL_LIBS}
-    echo "This script only allows rebuilding for gnutls and dependencies"
-    echo "Exiting.."
-    exit 1
-fi
-
 rebuild_dependencies "${ACTION}" "${APP}"
 
 if [ "${rebuild}" = "yes" ]; then


### PR DESCRIPTION
This removes the check just for gnutls. At this point, the setup is that:

1. The nightly script will copy any needed homebrew libraries into the app bundle by calling build-homebrew-libraries.sh. It gives an error if the versions are incompatible.

2. You can run `sh build-homebrew-libraries.sh -rebuild` after you do any homebrew updates that might affect things.

And it's probably sufficient to build a release. If you run into problems, I'll try to turn around any fixes quickly.

