### PR TITLE
Avoid zero-size scroll requests due to integer division.

### DIFF
--- a/aquamacs/src/site-lisp/aquamacs.el
+++ b/aquamacs/src/site-lisp/aquamacs.el
@@ -658,15 +658,15 @@ if modified buffers exist."
 
 (defcustom mouse-wheel-progressive-decelerator 4.0
   "Decelerate progressive mouse wheel scrolling by this factor.
-Must be 1 or larger."
+Must be a float, 1.0 or larger"
   :group 'mouse
   :group 'Aquamacs
   :type 'float)
 
 (defun aquamacs-wheel-scroll-down (&optional amt)
-  "If `mouse-wheel-progressive-speed' is on, divide number of lines
-to be scrolled by `mouse-wheel-progressive-decelerator', rounding up,
-before scrolling down. Otherwise, simply scroll down AMT lines. "
+  "If `mouse-wheel-progressive-speed' is on, divide AMT by
+`mouse-wheel-progressive-decelerator', rounding up, before scrolling down
+that many lines. Otherwise, simply scroll down AMT lines."
   (if amt
       (let ((amt1
 	     (if mouse-wheel-progressive-speed
@@ -675,9 +675,9 @@ before scrolling down. Otherwise, simply scroll down AMT lines. "
     (scroll-down)))
 
 (defun aquamacs-wheel-scroll-up (&optional amt)
-  "If `mouse-wheel-progressive-speed' is on, divide number of lines
-to be scrolled by `mouse-wheel-progressive-decelerator', rounding up,
-before scrolling up. Otherwise, simply scroll up AMT lines. "
+  "If `mouse-wheel-progressive-speed' is on, divide AMT by
+`mouse-wheel-progressive-decelerator', rounding up, before scrolling up
+that many lines. Otherwise, simply scroll up AMT lines."
   (if amt
       (let ((amt1
 	     (if mouse-wheel-progressive-speed

--- a/aquamacs/src/site-lisp/aquamacs.el
+++ b/aquamacs/src/site-lisp/aquamacs.el
@@ -656,7 +656,7 @@ if modified buffers exist."
     (message "mwheel-install ignored in Aquamacs. Mouse wheel support is present by default.")
     t)
 
-(defcustom mouse-wheel-progressive-decelerator 4
+(defcustom mouse-wheel-progressive-decelerator 4.0
   "Decelerate progressive mouse wheel scrolling by this factor.
 Must be 1 or larger."
   :group 'mouse
@@ -664,15 +664,25 @@ Must be 1 or larger."
   :type 'float)
 
 (defun aquamacs-wheel-scroll-down (&optional amt)
-  "Scroll down (/ AMT mouse-wheel-progressive-decelerator) units"
+  "If `mouse-wheel-progressive-speed' is on, divide number of lines
+to be scrolled by `mouse-wheel-progressive-decelerator', rounding up,
+before scrolling down. Otherwise, simply scroll down AMT lines. "
   (if amt
-      (scroll-down (/ amt mouse-wheel-progressive-decelerator))
+      (let ((amt1
+	     (if mouse-wheel-progressive-speed
+		 (ceiling (/ amt mouse-wheel-progressive-decelerator)) amt)))
+	(scroll-down amt1))
     (scroll-down)))
 
 (defun aquamacs-wheel-scroll-up (&optional amt)
-  "Scroll up (/ AMT mouse-wheel-progressive-decelerator) units"
+  "If `mouse-wheel-progressive-speed' is on, divide number of lines
+to be scrolled by `mouse-wheel-progressive-decelerator', rounding up,
+before scrolling up. Otherwise, simply scroll up AMT lines. "
   (if amt
-      (scroll-up (/ amt mouse-wheel-progressive-decelerator))
+      (let ((amt1
+	     (if mouse-wheel-progressive-speed
+		 (ceiling (/ amt mouse-wheel-progressive-decelerator)) amt)))
+	(scroll-up amt1))
     (scroll-up)))
 
 (aquamacs-set-defaults


### PR DESCRIPTION
There were two issues with the recent introduction of `mouse-wheel-progressive-decelerator', that are fixed by this patch:
1) The requested scroll amount was divided by the `-progressive-decelerator' value, even when progressive scrolling was turned off.
2) Integer division resulted in zero scroll size requested,
  - always, when progressive scrolling was off; and
  - for the first few scrolls with progressive scrolling on.

This fix
A) changes `mouse-wheel-progressive-decelerator' to a float value so division gives floating-point (untruncated!) result;
B) applies (ceiling) to the (float) result from division, because the `scroll-up' and `scroll-down' functions that are subsequently called will only scroll a single line if given a float argument;
C) only divides by `-progressive-decelerator' value when progressive scrolling is on.