### PR TITLE
Issue 194: cmd-meta-h bound to ns-do-hide-others

### DIFF
--- a/aquamacs/doc/latex/changelog.tex
+++ b/aquamacs/doc/latex/changelog.tex
@@ -17,6 +17,7 @@
 \item Fixed issue #185: Add Mac OS permission requests for various system operations, including AppleScript
 \item Fixed issue #195: Backported fix for Mach port leak from Emacs (bug 38618)
 \item Fixed issue #182: Aquamacs won't build on Catalina
+\item Fixed issue #194: cmd-meta-h hides non-emacs frames
 
 \subsection{Changes--- 3.5}
 \begin{itemize}

--- a/aquamacs/src/site-lisp/macosx/osxkeys.el
+++ b/aquamacs/src/site-lisp/macosx/osxkeys.el
@@ -873,6 +873,8 @@ which key is mapped to command. The value of
     (define-key map `[(,osxkeys-command-key shift g)] 'aquamacs-repeat-isearch-backward)
     (if (fboundp 'ns-do-hide-emacs)
 	(define-key map `[(,osxkeys-command-key h)] 'ns-do-hide-emacs))
+    (if (fboundp 'ns-do-hide-others)
+	(define-key map `[(,osxkeys-command-key meta h)] 'ns-do-hide-others))
     (define-key map `[(,osxkeys-command-key e)] 'aquamacs-use-selection-for-find)
     (define-key map `[(,osxkeys-command-key w)] 'close-window)
     (define-key map `[(,osxkeys-command-key m)] 'iconify-or-deiconify-frame) 

--- a/lisp/textmodes/reftex.el
+++ b/lisp/textmodes/reftex.el
@@ -2695,7 +2695,7 @@ With no argument, this command toggles
 
 ;;;***
 
-;;;### (autoloads nil "reftex-index" "reftex-index.el" "a3e1ce5ba2b769a6a3a8f3a60ac87397")
+;;;### (autoloads nil "reftex-index" "reftex-index.el" "00c143bc478804d464019d61251b2fb8")
 ;;; Generated autoloads from reftex-index.el
 
 (autoload 'reftex-index-selection-or-word "reftex-index" "\


### PR DESCRIPTION
cmd-meta-h is now bound to ns-do-hide-others.  This should replicate MacOS behavior with uses Cmd-Option-H to hide other windows, as long as Option is bound to meta.