### PR TITLE
fix failing flymake test

### DIFF
--- a/test/automated/data/flymake/Makefile
+++ b/test/automated/data/flymake/Makefile
@@ -8,6 +8,6 @@ CC_OPTS = -Wall
 ## normally use flymake, so it seems like just avoiding the issue
 ## in this test is fine.  Set flymake-log-level to 3 to investigate.
 check-syntax:
-	GCC_COLORS= $(CC) $(CC_OPTS) ${CHK_SOURCES}
+	GCC_COLORS= CCC_OVERRIDE_OPTIONS="+-fno-color-diagnostics" $(CC) $(CC_OPTS) ${CHK_SOURCES}
 
 # eof


### PR DESCRIPTION
Colors in clang's output were confusing flymake. Add clang specific
env variable to suppress color output.

see #197