### PR TITLE
fix auto-revert-tests

### DIFF
--- a/test/automated/auto-revert-tests.el
+++ b/test/automated/auto-revert-tests.el
@@ -28,6 +28,10 @@
 (setq auto-revert-notify-exclude-dir-regexp "nothing-to-be-excluded"
       auto-revert-stop-on-user-input nil)
 
+(when (string= system-type "darwin")
+  (setq ls-lisp-use-insert-directory-program nil)
+  (require 'ls-lisp))
+
 (defconst auto-revert--timeout 10
   "Time to wait until a message appears in the *Messages* buffer.")
 


### PR DESCRIPTION
`dired-noselect` throwing an error (that should probably be a warning)
when using a non-gnu `ls`. use dired's internal `ls` instead.

see #197 