### PR TITLE
display-mm-[height/width] return same values as Emacs-OSX

### DIFF
--- a/src/nsfns.m
+++ b/src/nsfns.m
@@ -2597,19 +2597,11 @@ If omitted or nil, that stands for the selected frame's display.
 On \"multi-monitor\" setups this refers to the height in millimeters for
 all physical monitors associated with TERMINAL.  To get information
 for each physical monitor, use `display-monitor-attributes-list'.  */)
-  (Lisp_Object display)
+  (Lisp_Object terminal)
 {
-  check_ns_display_info (display);
-
-  NSScreen *screen = ns_get_screen (display);
-
-  CGDirectDisplayID displayID = (CGDirectDisplayID)[[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
-  CGSize physicalSize = CGDisplayScreenSize(displayID);
-
-  // height in mm
-  return make_number ((int) physicalSize.height);
+  struct ns_display_info *dpyinfo = check_ns_display_info (terminal);
+  return make_number (x_display_pixel_height (dpyinfo) / (92.0/25.4));
 }
-
 
 DEFUN ("x-display-mm-width", Fx_display_mm_width, Sx_display_mm_width, 0, 1, 0,
        doc: /* Return the width in millimeters of the Nextstep display TERMINAL.
@@ -2617,20 +2609,13 @@ The optional argument TERMINAL specifies which display to ask about.
 TERMINAL should be a terminal object, a frame or a display name (a string).
 If omitted or nil, that stands for the selected frame's display.
 
-On \"multi-monitor\" setups this refers to the width in millimeters for
+On \"multi-monitor\" setups this refers to the height in millimeters for
 all physical monitors associated with TERMINAL.  To get information
 for each physical monitor, use `display-monitor-attributes-list'.  */)
-  (Lisp_Object display)
+  (Lisp_Object terminal)
 {
-  check_ns_display_info (display);
-
-  NSScreen *screen = ns_get_screen (display);
-
-  CGDirectDisplayID displayID = (CGDirectDisplayID)[[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
-  CGSize physicalSize = CGDisplayScreenSize(displayID);
-
-  // width in mm
-  return make_number ((int) physicalSize.width);
+  struct ns_display_info *dpyinfo = check_ns_display_info (terminal);
+  return make_number (x_display_pixel_width (dpyinfo) / (92.0/25.4));
 }
 
 


### PR DESCRIPTION
The "standard" Emacs behavior of `display-mm-width` and `display-mm-height` is to return the combined dimensions of all monitors connected to a display.  Aquamacs was returning the physical dimensions for individual monitors, based on the location of the selected frame.  This commit reverts Aquamacs to return the same values as the Emacs-for-Mac-OSX build.  This is important for compatibility with the Emacs package universe.

Specifically, this commit solves the problem of preview-latex (in AucTeX) inserting images with the wrong aspect ratio.  For example, in my setup with two monitors side-by-side, Emacs reports a width of 1656mm, while Aquamacs reported a width of 801mm for one monitor, and 596 for the other.  Thus, preview-latex applied too high of a pixel-to-mm ratio, and images were twice as wide as they should be.  By correctly reporting the physical dimensions of the display, the problem is solved.

However, this commit does bring back another issue with high-resolution displays, but one for which I think Aquamacs is correct and Emacs is not.  Emacs infers the physical dimensions from the pixel height/width, assuming a fixed resolution of 92ppi.  If at least one of the monitors on a display is high resolution (e.g., Retina, 4K), Emacs will think the display is physically larger than it actually is. The Aquamacs behavior was to query the display directly, so it got an accurate metric, but was only reporting for one monitor at a time. In the example above, note that 801 + 596 (separate monitor widths) is less than 1656 (reported width of the display).

Fortunately, `display-mm-width` and `display-mm-height` don't seem to be used very often (I think preview-latex is their only appearance in the Aquamacs package bundle). So even though this commit gives mm dimensions that are a little off in some situations, the proportions and aspect ratio are now correct, and I think that's more important.